### PR TITLE
[FEAT]/#11-예외처리 방식 제안

### DIFF
--- a/src/main/java/umc/project/umark/global/exception/GlobalErrorCode.java
+++ b/src/main/java/umc/project/umark/global/exception/GlobalErrorCode.java
@@ -1,0 +1,40 @@
+package umc.project.umark.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Getter
+@AllArgsConstructor
+public enum GlobalErrorCode {
+    //  Member
+    // 400 BAD_REQUEST - 잘못된 요청
+    NOT_VALID_EMAIL(BAD_REQUEST, "유효하지 않은 이메일 입니다."),
+    PASSWORD_MISMATCH(BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    DUPLICATE_PASSWORD(BAD_REQUEST, "비밀번호가 동일합니다."),
+    NOT_VALID_PASSWORD(BAD_REQUEST, "영문, 숫자, 특수문자를 포함한 8~20 글자를 입력해 주세요."),
+
+    // 401 Unauthorized - 권한 없음
+    INVALID_TOKEN(UNAUTHORIZED, "토큰이 유효하지 않습니다."),
+    LOGIN_REQUIRED(UNAUTHORIZED, "로그인이 필요한 서비스입니다."),
+    INVALID_CODE(UNAUTHORIZED, "유효하지 않은 코드입니다."),
+    AUTHENTICATION_REQUIRED(UNAUTHORIZED, "인증 정보가 유효하지 않습니다."),
+    // 404 Not Found - 찾을 수 없음
+    EMAIL_NOT_FOUND(NOT_FOUND, "존재하지 않는 이메일 입니다."),
+    NEED_AGREE_REQUIRE_TERMS(NOT_FOUND, "필수 약관에 동의해 주세요."),
+    MEMBER_NOT_FOUND(NOT_FOUND, "등록된 사용자가 없습니다."),
+    MEMBER_INFO_NOT_FOUND(NOT_FOUND, "등록된 사용자 정보가 없습니다."),
+    // 409 CONFLICT : Resource 를 찾을 수 없음
+    DUPLICATE_EMAIL(CONFLICT, "중복된 이메일이 존재합니다."),
+    EXPIRED_REFRESH_TOKEN(BAD_REQUEST, "유효기간이 지난 토큰입니다."),
+    ;
+
+
+
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/umc/project/umark/global/exception/GlobalException.java
+++ b/src/main/java/umc/project/umark/global/exception/GlobalException.java
@@ -1,0 +1,11 @@
+package umc.project.umark.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GlobalException extends RuntimeException {
+    private final GlobalErrorCode errorCode;
+}
+

--- a/src/main/java/umc/project/umark/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/umc/project/umark/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package umc.project.umark.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(value = { GlobalException.class})
+    protected ResponseEntity handleCustomException(GlobalException e) {
+        log.error("handleCustomException throw CustomException : {}", e.getErrorCode());
+        return ApiResponse.ErrorResponse(e.getErrorCode());
+    }
+
+}


### PR DESCRIPTION
개요
GlobalException과 GlobalErrorCode를 이용한 예외 처리 방식

세부 내용
GlobalException 클래스
RuntimeException을 extends
GlobalErrorCode 클래스(enum)
에러코드들 (400~500번대) 을 저장
API 응답에 포함 시키기 위한 httpStatus와 message
GlobalExceptionHandler
GlobalException 타입의 예외 발생 시 처리하는 메서드
ApiResponse 클래스와 그 속에 ErrorResponse 빌더 필요