### PR TITLE
[CHORE]/#22-ApiResponse&GlobalException 수정

### DIFF
--- a/src/main/java/umc/project/umark/domain/term/controller/TermController.java
+++ b/src/main/java/umc/project/umark/domain/term/controller/TermController.java
@@ -1,0 +1,27 @@
+package umc.project.umark.domain.term.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import umc.project.umark.domain.term.dto.TermDto;
+import umc.project.umark.domain.term.service.TermService;
+
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class TermController {
+
+    private final TermService termService;
+
+//    @PostMapping("/term/add")
+//    public Object addTerm(
+//            @RequestBody TermDto.TermRequestDto requestDto
+//    ) {
+//        termService.createTerm(requestDto);
+//        return null;
+//    }
+
+}

--- a/src/main/java/umc/project/umark/domain/term/dto/TermDto.java
+++ b/src/main/java/umc/project/umark/domain/term/dto/TermDto.java
@@ -1,0 +1,19 @@
+package umc.project.umark.domain.term.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class TermDto {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TermRequestDto {
+        String description;
+        Boolean isAgree;
+        Boolean isCrucial;
+    }
+}

--- a/src/main/java/umc/project/umark/domain/term/entity/Term.java
+++ b/src/main/java/umc/project/umark/domain/term/entity/Term.java
@@ -1,4 +1,4 @@
-package umc.project.umark.domain.term;
+package umc.project.umark.domain.term.entity;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/umc/project/umark/domain/term/repository/TermRepository.java
+++ b/src/main/java/umc/project/umark/domain/term/repository/TermRepository.java
@@ -1,0 +1,7 @@
+package umc.project.umark.domain.term.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.project.umark.domain.term.entity.Term;
+
+public interface TermRepository extends JpaRepository<Term, Long> {
+}

--- a/src/main/java/umc/project/umark/domain/term/service/TermService.java
+++ b/src/main/java/umc/project/umark/domain/term/service/TermService.java
@@ -1,0 +1,7 @@
+package umc.project.umark.domain.term.service;
+
+import umc.project.umark.domain.term.dto.TermDto;
+
+public interface TermService {
+    public void createTerm(TermDto.TermRequestDto requestDto);
+}

--- a/src/main/java/umc/project/umark/domain/term/service/TermServiceImpl.java
+++ b/src/main/java/umc/project/umark/domain/term/service/TermServiceImpl.java
@@ -1,0 +1,34 @@
+package umc.project.umark.domain.term.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.project.umark.domain.term.dto.TermDto;
+import umc.project.umark.domain.term.entity.Term;
+import umc.project.umark.domain.term.repository.TermRepository;
+import umc.project.umark.global.exception.GlobalErrorCode;
+import umc.project.umark.global.exception.GlobalException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TermServiceImpl implements TermService{
+    private final TermRepository termRepository;
+
+//    @Override
+//    @Transactional
+//    public void createTerm(TermDto.TermRequestDto requestDto) {
+//        if (requestDto.getIsAgree() == null) {
+//            throw new GlobalException(GlobalErrorCode.MEMBER_NOT_FOUND);
+//        };
+//        Term newTerm =  Term.builder()
+//                .description(requestDto.getDescription())
+//                .isCrucial(requestDto.getIsCrucial())
+//                .build();
+//
+//        termRepository.save(newTerm);
+//
+//        log.info("New Term created with id: {}", newTerm.getId());
+//    }
+}

--- a/src/main/java/umc/project/umark/global/common/ApiResponse.java
+++ b/src/main/java/umc/project/umark/global/common/ApiResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import umc.project.umark.global.exception.GlobalErrorCode;
 
 @Getter
 @AllArgsConstructor
@@ -25,8 +26,8 @@ public class ApiResponse<T> {
     }
 
     // 실패한 경우 응답 생성
-    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
-        return new ApiResponse<>(false, code, message, data);
+    public static <T> ApiResponse<T> onFailure(GlobalErrorCode code,  T data){
+        return new ApiResponse<>(false, String.valueOf(code.getHttpStatus().value()), code.getMessage(), data);
     }
 
 }

--- a/src/main/java/umc/project/umark/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/umc/project/umark/global/exception/GlobalExceptionHandler.java
@@ -1,18 +1,18 @@
 package umc.project.umark.global.exception;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import umc.project.umark.global.common.ApiResponse;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    //@ExceptionHandler(value = { GlobalException.class})
-    //protected ResponseEntity handleCustomException(GlobalException e) {
-      //  log.error("handleCustomException throw CustomException : {}", e.getErrorCode());
-        // return ApiResponse.ErrorResponse(e.getErrorCode());
-    //}
+    @ExceptionHandler(value = { GlobalException.class})
+    protected ApiResponse handleCustomException(GlobalException e) {
+        log.error("handleCustomException throw CustomException : {}", e.getErrorCode());
+         return ApiResponse.onFailure(e.getErrorCode(), "");
+    }
 
 }


### PR DESCRIPTION
1. ApiResponse의 onFailure함수가 GlobalException 발생 시, GlobalErrorCode를 참고하여 응답을 생성이 가능하도록 수정해였습니다.

2. String.valueOf(code.getHttpStatus().value())를 이용해 에러코드를 가져오고 code.getMessage() 를 이용해 "~이 없습니다" 와 같은 에러 메세지를 가져올 수 있습니다.

3. 서비스나 컨트롤러에서 throw new GlobalException(GlobalErrorCode.MEMBER_NOT_FOUND) 와 같은 방식으로 예외 발생 감지가 가능한 것을 Term 관련 클래스들을 임시로 만들어서 확인했습니다.

결과
![image](https://github.com/UMC-Umark/umark-server/assets/120353547/055307b0-aa1f-495f-9f45-f51d8122ee4d)

추가적으로, 저희가 사전에 이야기한 형식을 지켜 result 대신 data로 수정하여 각자 컨트롤러나 컨버터에 반영 부탁드립니다!
