### PR TITLE
[FEAT]/#24-MemberQueryService + 일부 코드 리팩토링

### DIFF
--- a/src/main/java/umc/project/umark/domain/member/controller/MemberController.java
+++ b/src/main/java/umc/project/umark/domain/member/controller/MemberController.java
@@ -1,33 +1,32 @@
 package umc.project.umark.domain.member.controller;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
 import umc.project.umark.domain.member.converter.MemberConverter;
 import umc.project.umark.domain.member.dto.MemberDto;
-import umc.project.umark.domain.member.service.MemberServiceImpl;
+import umc.project.umark.domain.member.service.MemberService;
 import umc.project.umark.global.exception.ApiResponse;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import umc.project.umark.global.exception.GlobalException;
 
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("api/member")
 public class MemberController {
 
-    @Autowired
-    private MemberServiceImpl memberServiceImpl;
+    private final MemberService memberService;
 
     @PostMapping("/sendemail")
     public ApiResponse<Map<String, Object>> sendEmail(@RequestBody MemberDto.MemberSignUpDto memberSignUpDto) throws IOException {
         Map<String, Object> response =  new HashMap<>();
         try{
-            Boolean result = memberServiceImpl.sendEmail(memberSignUpDto.getEmail(), memberSignUpDto.getUnivName());
+            Boolean result = memberService.sendEmail(memberSignUpDto.getEmail(), memberSignUpDto.getUnivName());
             response.put("success", result);
             return new ApiResponse<>(true, "200", "성공하였습니다", response);
         } catch (IOException e) {
@@ -40,7 +39,7 @@ public class MemberController {
     public ApiResponse<Map<String, Object>> checkEmail(@RequestBody MemberDto.MemberSignUpDto memberSignUpDto) throws IOException {
         Map<String, Object> response = new HashMap<>();
         try{
-            Boolean result = memberServiceImpl.checkEmail(memberSignUpDto.getEmail(), memberSignUpDto.getUnivName(), memberSignUpDto.getCode());
+            Boolean result = memberService.checkEmail(memberSignUpDto.getEmail(), memberSignUpDto.getUnivName(), memberSignUpDto.getCode());
             response.put("success", result);
             return new ApiResponse<>(true, "200", "성공하였습니다", response);
         } catch (IOException e){
@@ -54,10 +53,27 @@ public class MemberController {
         String email = memberSignUpDto.getEmail();
         String password = memberSignUpDto.getPassword();
         try{
-            memberServiceImpl.signUpMember(email, password);
-            return ApiResponse.onSuccess(MemberConverter.memberResponseDto(email, password));
+            return ApiResponse.onSuccess(MemberConverter.memberResponseDto(memberService.signUpMember(email, password)));
         } catch (GlobalException e){
-            return ApiResponse.onFailure(e.getErrorCode(), MemberConverter.memberResponseDto(email, password));
+            return ApiResponse.onFailure(e.getErrorCode(), MemberConverter.memberResponseDto(memberService.signUpMember(email, password)));
+        }
+    }
+
+    @GetMapping("/{memberId}")
+    public ApiResponse<MemberDto.MemberResponseDto> getMember(@PathVariable Long memberId){
+        try{
+            return ApiResponse.onSuccess(memberService.getMember(memberId));
+        } catch (GlobalException e){
+            return ApiResponse.onFailure(e.getErrorCode(), null);
+        }
+    }
+
+    @GetMapping("/all")
+    public ApiResponse<List<MemberDto.MemberResponseDto>> getAllMembers(){
+        try{
+            return ApiResponse.onSuccess(memberService.getAllMembers());
+        } catch (GlobalException e){
+            return ApiResponse.onFailure(e.getErrorCode(), null);
         }
     }
 

--- a/src/main/java/umc/project/umark/domain/member/converter/MemberConverter.java
+++ b/src/main/java/umc/project/umark/domain/member/converter/MemberConverter.java
@@ -1,6 +1,7 @@
 package umc.project.umark.domain.member.converter;
 
 import umc.project.umark.domain.member.dto.MemberDto;
+import umc.project.umark.domain.member.entity.Member;
 import umc.project.umark.domain.member.entity.MemberStatus;
 
 public class MemberConverter {
@@ -13,11 +14,11 @@ public class MemberConverter {
                 .build();
     }
 
-    public static MemberDto.MemberResponseDto memberResponseDto(String email, String password){
+    public static MemberDto.MemberResponseDto memberResponseDto(Member member){
         return MemberDto.MemberResponseDto.builder()
-                .email(email)
-                .password(password)
-                .memberStatus(MemberStatus.ACTIVE.toString())
+                .email(member.getEmail())
+                .password(member.getPassword())
+                .memberStatus(String.valueOf(member.getMemberStatus()))
                 .build();
     }
 }

--- a/src/main/java/umc/project/umark/domain/member/entity/Member.java
+++ b/src/main/java/umc/project/umark/domain/member/entity/Member.java
@@ -23,9 +23,11 @@ public class Member extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private MemberStatus memberStatus;
-
+    @Column
+    @Builder.Default
     private Integer writtenCount = 0;
-
+    @Column
+    @Builder.Default
     private Integer likedCount = 0;
 
     public void increaseWrittenCount() {

--- a/src/main/java/umc/project/umark/domain/member/service/MemberService.java
+++ b/src/main/java/umc/project/umark/domain/member/service/MemberService.java
@@ -1,8 +1,10 @@
 package umc.project.umark.domain.member.service;
 
+import umc.project.umark.domain.member.dto.MemberDto;
 import umc.project.umark.domain.member.entity.Member;
 
 import java.io.IOException;
+import java.util.List;
 
 public interface MemberService {
 
@@ -11,4 +13,6 @@ public interface MemberService {
     public Boolean checkEmail(String email, String univName, int code) throws  IOException;
 
     public Member signUpMember(String email, String password);
+    public MemberDto.MemberResponseDto getMember(Long memberId);
+    public List<MemberDto.MemberResponseDto> getAllMembers();
 }

--- a/src/main/java/umc/project/umark/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/umc/project/umark/domain/member/service/MemberServiceImpl.java
@@ -6,6 +6,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.project.umark.domain.member.converter.MemberConverter;
+import umc.project.umark.domain.member.dto.MemberDto;
 import umc.project.umark.domain.member.repository.MemberRepository;
 import umc.project.umark.domain.member.entity.MemberStatus;
 import umc.project.umark.domain.member.entity.Member;
@@ -13,6 +15,8 @@ import umc.project.umark.global.exception.GlobalErrorCode;
 import umc.project.umark.global.exception.GlobalException;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -83,6 +87,34 @@ public class MemberServiceImpl implements MemberService {
 
             return member;
         }
+    }
+
+    @Override
+    public MemberDto.MemberResponseDto getMember(Long memberId) {
+        Optional<Member> findMember = memberRepository.findById(memberId);
+
+        if (findMember.isPresent()) {
+            Member member = findMember.get();
+            MemberDto.MemberResponseDto memberResponseDto= MemberConverter.memberResponseDto(member);
+            return memberResponseDto;
+        }
+
+        else{
+            throw new GlobalException(GlobalErrorCode.MEMBER_NOT_FOUND);
+        }
+    }
+
+    @Override
+    public List<MemberDto.MemberResponseDto> getAllMembers() {
+        List<Member> members = memberRepository.findAll();
+        List<MemberDto.MemberResponseDto> memberResponseDtos = new ArrayList<>();
+
+        for (Member member : members) {
+            MemberDto.MemberResponseDto memberResponseDto = MemberConverter.memberResponseDto(member);
+            memberResponseDtos.add(memberResponseDto);
+        }
+
+        return memberResponseDtos;
     }
 
 }

--- a/src/main/java/umc/project/umark/domain/term/controller/TermController.java
+++ b/src/main/java/umc/project/umark/domain/term/controller/TermController.java
@@ -14,7 +14,7 @@ import umc.project.umark.domain.term.service.TermService;
 @Slf4j
 public class TermController {
 
-    private final TermService termService;
+//    private final TermService termService;
 
 //    @PostMapping("/term/add")
 //    public Object addTerm(

--- a/src/main/java/umc/project/umark/domain/term/entity/Term.java
+++ b/src/main/java/umc/project/umark/domain/term/entity/Term.java
@@ -23,6 +23,7 @@ public class Term extends BaseEntity {
     private String description;
 
     @Column(nullable = false)
+    @Builder.Default
     private Boolean isAgree = false;
 
     @Column(nullable = false)

--- a/src/main/java/umc/project/umark/domain/term/service/TermServiceImpl.java
+++ b/src/main/java/umc/project/umark/domain/term/service/TermServiceImpl.java
@@ -1,34 +1,34 @@
-package umc.project.umark.domain.term.service;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import umc.project.umark.domain.term.dto.TermDto;
-import umc.project.umark.domain.term.entity.Term;
-import umc.project.umark.domain.term.repository.TermRepository;
-import umc.project.umark.global.exception.GlobalErrorCode;
-import umc.project.umark.global.exception.GlobalException;
-
-@Service
-@RequiredArgsConstructor
-@Slf4j
-public class TermServiceImpl implements TermService{
-    private final TermRepository termRepository;
-
-//    @Override
-//    @Transactional
-//    public void createTerm(TermDto.TermRequestDto requestDto) {
-//        if (requestDto.getIsAgree() == null) {
-//            throw new GlobalException(GlobalErrorCode.MEMBER_NOT_FOUND);
-//        };
-//        Term newTerm =  Term.builder()
-//                .description(requestDto.getDescription())
-//                .isCrucial(requestDto.getIsCrucial())
-//                .build();
+//package umc.project.umark.domain.term.service;
 //
-//        termRepository.save(newTerm);
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.stereotype.Service;
+//import org.springframework.transaction.annotation.Transactional;
+//import umc.project.umark.domain.term.dto.TermDto;
+//import umc.project.umark.domain.term.entity.Term;
+//import umc.project.umark.domain.term.repository.TermRepository;
+//import umc.project.umark.global.exception.GlobalErrorCode;
+//import umc.project.umark.global.exception.GlobalException;
 //
-//        log.info("New Term created with id: {}", newTerm.getId());
-//    }
-}
+//@Service
+//@RequiredArgsConstructor
+//@Slf4j
+//public class TermServiceImpl implements TermService{
+//    private final TermRepository termRepository;
+//
+////    @Override
+////    @Transactional
+////    public void createTerm(TermDto.TermRequestDto requestDto) {
+////        if (requestDto.getIsAgree() == null) {
+////            throw new GlobalException(GlobalErrorCode.MEMBER_NOT_FOUND);
+////        };
+////        Term newTerm =  Term.builder()
+////                .description(requestDto.getDescription())
+////                .isCrucial(requestDto.getIsCrucial())
+////                .build();
+////
+////        termRepository.save(newTerm);
+////
+////        log.info("New Term created with id: {}", newTerm.getId());
+////    }
+//}

--- a/src/main/java/umc/project/umark/global/common/ApiResponse.java
+++ b/src/main/java/umc/project/umark/global/common/ApiResponse.java
@@ -17,12 +17,12 @@ public class ApiResponse<T> {
     private String code;
     private String message;
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private T result;
+    private T data;
 
     // 성공한 경우 응답 생성
 
-    public static <T> ApiResponse<T> onSuccess(T result){
-        return new ApiResponse<>(true, "200" , "요청에 성공하였습니다.", result);
+    public static <T> ApiResponse<T> onSuccess(T data){
+        return new ApiResponse<>(true, "200" , "요청에 성공하였습니다.", data);
     }
 
     // 실패한 경우 응답 생성


### PR DESCRIPTION
# 코드 리팩토링

1. MemberController 쪽 일부 리팩토링 - MemberService 호출 부분 -> private final 활용하는 방식으로 변경
2. ApiResponse - 사전 협의한 컨벤션에 맞게 result -> data로 변경
3. 현재 사용하지 않는 코드(Term관련) 주석처리 -> 추후 수정 예정

# 기능 구현

1. GET: /api/member/{memberId} - 특정 멤버의 id를 기반으로 멤버의 email, password, status 반환
2. GET: /api/member/all - 가입된 모든 멤버의 email, password, status를 리스트로 반환