### PR TITLE
Feature/#26 member 비밀번호변경및찾기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.github.in-seo:univcert:master-SNAPSHOT' //학교 이메일 체크
     implementation 'com.googlecode.json-simple:json-simple:1.1.1' //json 파싱
+    implementation 'org.springframework.boot:spring-boot-starter-mail' //java mail
 }
 
 tasks.named('test') {

--- a/src/main/java/umc/project/umark/domain/member/controller/MemberController.java
+++ b/src/main/java/umc/project/umark/domain/member/controller/MemberController.java
@@ -16,7 +16,7 @@ import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/member")
+@RequestMapping("/member")
 public class MemberController {
 
     private final MemberService memberService;
@@ -76,6 +76,7 @@ public class MemberController {
         }
     }
 
+    /*
     @PostMapping("/sendpasswordmail")
     public ApiResponse<String> snedFindPasswordMail(@RequestBody MemberDto.MemberFindPasswordDto findPasswordDto) {
         try {
@@ -84,6 +85,7 @@ public class MemberController {
             return ApiResponse.onFailure(e.getErrorCode(), null);
         }
     }
+     */
 
     @PatchMapping("/changepasswordbyemail")
     public ApiResponse<MemberDto.MemberResponseDto> changePasswordByEmail(@RequestBody MemberDto.MemberFindPasswordDto findPasswordDto) {

--- a/src/main/java/umc/project/umark/domain/member/controller/MemberController.java
+++ b/src/main/java/umc/project/umark/domain/member/controller/MemberController.java
@@ -6,7 +6,6 @@ import umc.project.umark.domain.member.converter.MemberConverter;
 import umc.project.umark.domain.member.dto.MemberDto;
 import umc.project.umark.domain.member.service.MemberService;
 import umc.project.umark.global.exception.ApiResponse;
-import org.springframework.beans.factory.annotation.Autowired;
 import umc.project.umark.global.exception.GlobalException;
 
 
@@ -73,6 +72,33 @@ public class MemberController {
         try{
             return ApiResponse.onSuccess(memberService.getAllMembers());
         } catch (GlobalException e){
+            return ApiResponse.onFailure(e.getErrorCode(), null);
+        }
+    }
+
+    @PostMapping("/sendpasswordmail")
+    public ApiResponse<String> snedFindPasswordMail(@RequestBody MemberDto.MemberFindPasswordDto findPasswordDto) {
+        try {
+            return ApiResponse.onSuccess(memberService.sendFindPasswordMail(findPasswordDto.getEmail()));
+        } catch (GlobalException e) {
+            return ApiResponse.onFailure(e.getErrorCode(), null);
+        }
+    }
+
+    @PatchMapping("/changepasswordbyemail")
+    public ApiResponse<MemberDto.MemberResponseDto> changePasswordByEmail(@RequestBody MemberDto.MemberFindPasswordDto findPasswordDto) {
+        try {
+            return ApiResponse.onSuccess(MemberConverter.memberResponseDto(memberService.changePasswordByEmail(findPasswordDto.getEmail(), findPasswordDto.getNewPassword())));
+        } catch (GlobalException e) {
+            return ApiResponse.onFailure(e.getErrorCode(), null);
+        }
+    }
+
+    @PatchMapping("/changepassword/{memberId}")
+    public ApiResponse<MemberDto.MemberResponseDto> changePassword(@RequestBody MemberDto.MemberFindPasswordDto findPasswordDto, @PathVariable Long memberId) {
+        try {
+            return ApiResponse.onSuccess(MemberConverter.memberResponseDto(memberService.changePassword(memberId, findPasswordDto.getNewPassword())));
+        } catch (GlobalException e) {
             return ApiResponse.onFailure(e.getErrorCode(), null);
         }
     }

--- a/src/main/java/umc/project/umark/domain/member/dto/MemberDto.java
+++ b/src/main/java/umc/project/umark/domain/member/dto/MemberDto.java
@@ -27,4 +27,14 @@ public class MemberDto {
         private String memberStatus;
     }
 
+    @Builder
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberFindPasswordDto{
+        private String email;
+        private String newPassword;
+    }
+
 }

--- a/src/main/java/umc/project/umark/domain/member/entity/Member.java
+++ b/src/main/java/umc/project/umark/domain/member/entity/Member.java
@@ -49,4 +49,8 @@ public class Member extends BaseEntity {
             this.likedCount--;
         }
     }
+
+    public void changePassword(String newPassword) {
+        this.password = newPassword;
+    }
 }

--- a/src/main/java/umc/project/umark/domain/member/service/MemberService.java
+++ b/src/main/java/umc/project/umark/domain/member/service/MemberService.java
@@ -16,8 +16,8 @@ public interface MemberService {
     public Member signUpMember(String email, String password);
     public MemberDto.MemberResponseDto getMember(Long memberId);
     public List<MemberDto.MemberResponseDto> getAllMembers();
-    public String makeRandomCode();
-    public String sendFindPasswordMail(String email);
+    // public String makeRandomCode();
+    // public String sendFindPasswordMail(String email);
     public Member changePasswordByEmail(String email, String newPassword);
     public Member changePassword(Long memberId, String newPassword);
 }

--- a/src/main/java/umc/project/umark/domain/member/service/MemberService.java
+++ b/src/main/java/umc/project/umark/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package umc.project.umark.domain.member.service;
 
+import jakarta.mail.MessagingException;
 import umc.project.umark.domain.member.dto.MemberDto;
 import umc.project.umark.domain.member.entity.Member;
 
@@ -15,4 +16,8 @@ public interface MemberService {
     public Member signUpMember(String email, String password);
     public MemberDto.MemberResponseDto getMember(Long memberId);
     public List<MemberDto.MemberResponseDto> getAllMembers();
+    public String makeRandomCode();
+    public String sendFindPasswordMail(String email);
+    public Member changePasswordByEmail(String email, String newPassword);
+    public Member changePassword(Long memberId, String newPassword);
 }

--- a/src/main/java/umc/project/umark/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/umc/project/umark/domain/member/service/MemberServiceImpl.java
@@ -28,11 +28,11 @@ public class MemberServiceImpl implements MemberService {
     @Value("${univcert.apikey}")
     private String apiKey;
 
-    @Value("${spring.mail.username}")
-    private String sender;
+    //@Value("${spring.mail.username}")
+    //private String sender;
 
     private final MemberRepository memberRepository;
-    private final JavaMailSender javaMailSender;
+    // private final JavaMailSender javaMailSender;
 
     @Override
     public Boolean sendEmail(String email, String univName) throws IOException {
@@ -59,6 +59,7 @@ public class MemberServiceImpl implements MemberService {
             log.info("메일 인증 : {}", "메일 " + email + " 대학 " + univName + " 코드 " + code);
 
             if (result.get("success").equals(true)) {
+                UnivCert.clear(apiKey, email);
                 return true;
             }
 
@@ -72,7 +73,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional
-    public Member signUpMember(String email, String password) throws GlobalException {
+    public Member signUpMember(String email, String password) {
 
         Optional <Member> findMember = memberRepository.findByEmail(email);
 
@@ -121,6 +122,7 @@ public class MemberServiceImpl implements MemberService {
         return memberResponseDtos;
     }
 
+    /*
     @Override
     public String makeRandomCode() {
 
@@ -158,6 +160,8 @@ public class MemberServiceImpl implements MemberService {
 
         return code;
     }
+
+     */
 
     @Override
     @Transactional

--- a/src/main/java/umc/project/umark/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/umc/project/umark/domain/member/service/MemberServiceImpl.java
@@ -1,9 +1,11 @@
 package umc.project.umark.domain.member.service;
 
 import com.univcert.api.UnivCert;
+
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.project.umark.domain.member.converter.MemberConverter;
@@ -13,22 +15,24 @@ import umc.project.umark.domain.member.entity.MemberStatus;
 import umc.project.umark.domain.member.entity.Member;
 import umc.project.umark.global.exception.GlobalErrorCode;
 import umc.project.umark.global.exception.GlobalException;
+import org.springframework.mail.javamail.JavaMailSender;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
 
     @Value("${univcert.apikey}")
     private String apiKey;
 
-    @Autowired
-    private MemberRepository memberRepository;
+    @Value("${spring.mail.username}")
+    private String sender;
+
+    private final MemberRepository memberRepository;
+    private final JavaMailSender javaMailSender;
 
     @Override
     public Boolean sendEmail(String email, String univName) throws IOException {
@@ -115,6 +119,75 @@ public class MemberServiceImpl implements MemberService {
         }
 
         return memberResponseDtos;
+    }
+
+    @Override
+    public String makeRandomCode() {
+
+        //8자리 코드 생성
+
+        String codeSet = "ABCDEFGHIJKMNLOPQRSTUVWXYZ0123456789";
+        Random random = new Random();
+        StringBuilder randomCode = new StringBuilder();
+
+        for (int i=0; i<8; i++) {
+            int index = random.nextInt(codeSet.length());
+            randomCode.append(codeSet.charAt(index));
+        }
+
+        return String.valueOf(randomCode);
+    }
+
+    @Override
+    public String sendFindPasswordMail(String email) {
+
+        String code = makeRandomCode();
+
+        SimpleMailMessage mail = new SimpleMailMessage();
+
+        mail.setTo(email);
+        mail.setFrom(sender);
+        mail.setSubject("비밀번호 찾기 코드 메일");
+        mail.setText(code);
+
+        try {
+            javaMailSender.send(mail);
+        } catch (Exception e) {
+            throw e;
+        }
+
+        return code;
+    }
+
+    @Override
+    @Transactional
+    public Member changePasswordByEmail(String email, String newPassword) {
+        Optional <Member> findMember = memberRepository.findByEmail(email);
+
+        if (findMember.isPresent()) {
+            Member member = findMember.get();
+            member.changePassword(newPassword);
+            memberRepository.save(member);
+            return member;
+        } else {
+            throw new GlobalException(GlobalErrorCode.MEMBER_NOT_FOUND);
+        }
+    }
+
+    @Override
+    @Transactional
+    public Member changePassword(Long memberId, String newPassword) {
+        Optional <Member> findMember = memberRepository.findById(memberId);
+
+        if (findMember.isPresent()) {
+            Member member = findMember.get();
+            member.changePassword(newPassword);
+            memberRepository.save(member);
+            return member;
+        } else {
+            throw new GlobalException(GlobalErrorCode.INVALID_CODE);
+        }
+
     }
 
 }


### PR DESCRIPTION
비밀번호를 잊어버렸을 때 이메일을 통해 새로 설정하는 로직과 기존의 비밀번호를 변경하는 로직을 구현하였습니다.

1. 기능구현
POST : /api/member/sendpasswordmail - 비밀번호를 잊어버렸을 때 새로 설정할 때 유저 검증을 위한 메일 전송
PATCH : /api/member/changepasswordbyemail - 이메일 검증이 끝난 후 비밀번호를 변경하여 member 객체를 반환
PATCH : /api/member/changepassword/{memberId} - 비밀번호 변경 후 member 객체를 반환

-엔드포인트가 지저분하여 변경이 필요할 것 같습니다
-메일을 보내는 공용 계정을 따로 만들 필요가 있어보입니다
-현재 로그인을 구현하지 않아 로그인 구현 이후 비밀번호 변경은 토큰 값으로 진행되게 변경할 예정입니다
