### PR TITLE
북마크 삭제 

### DIFF
--- a/src/main/java/umc/project/umark/UmarkApplication.java
+++ b/src/main/java/umc/project/umark/UmarkApplication.java
@@ -2,7 +2,7 @@ package umc.project.umark;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
+
 
 @SpringBootApplication
 public class UmarkApplication {

--- a/src/main/java/umc/project/umark/domain/bookmark/controller/BookMarkController.java
+++ b/src/main/java/umc/project/umark/domain/bookmark/controller/BookMarkController.java
@@ -37,10 +37,10 @@ public class BookMarkController {
 
     }
 
-//    @DeleteMapping("/BookMarks")
-//    public ApiResponse<BookMarkResponse.BookMarkDeleteResponseDTO> deleteBookMark(@RequestParam Long bookMarkId,@RequestParam Long memberId){
-//
-//        //return ApiResponse.onSuccess(BookMarkConverter.toBookMarkDeleteResponseDTO(member));
-//    }
+   @DeleteMapping("/delete")
+   public ApiResponse<BookMarkResponse.BookMarkDeleteResponseDTO> deleteBookMark(@RequestParam Long bookMarkId,@RequestParam Long memberId){
+        Long deletedBookMarkId = bookMarkService.deleteBookMark(memberId,bookMarkId);
+       return ApiResponse.onSuccess(BookMarkConverter.toBookMarkDeleteResponseDTO(deletedBookMarkId));
+   }
 
 }

--- a/src/main/java/umc/project/umark/domain/bookmark/converter/BookMarkConverter.java
+++ b/src/main/java/umc/project/umark/domain/bookmark/converter/BookMarkConverter.java
@@ -1,5 +1,6 @@
 package umc.project.umark.domain.bookmark.converter;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -8,9 +9,11 @@ import umc.project.umark.domain.bookmark.dto.Request.BookMarkRequest;
 import umc.project.umark.domain.bookmark.entity.BookMark;
 import umc.project.umark.domain.mapping.BookMarkLike;
 import umc.project.umark.domain.member.entity.Member;
+import umc.project.umark.domain.member.repository.MemberRepository;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Optional;
 
 @Slf4j
 public class BookMarkConverter {
@@ -23,7 +26,7 @@ public class BookMarkConverter {
                 .build();
     }
 
-    public static BookMark toBookMark(BookMarkRequest.BookMarkCreateRequestDTO request){ //request로 받은 dto를 바탕으로 bookmark 생성
+    public static BookMark toBookMark(BookMarkRequest.BookMarkCreateRequestDTO request,Member member){ //request로 받은 dto를 바탕으로 bookmark 생성
 
        // content 내용을 로그로 출력
         log.info("Content received in request: {}", request.getContent());
@@ -32,6 +35,7 @@ public class BookMarkConverter {
                 .url(request.getUrl())
                 .content(request.getContent())
                 .bookMarkHashTags(new ArrayList<>())
+                .member(member)
                 .build();
     }
 

--- a/src/main/java/umc/project/umark/domain/bookmark/dto/Request/BookMarkRequest.java
+++ b/src/main/java/umc/project/umark/domain/bookmark/dto/Request/BookMarkRequest.java
@@ -26,6 +26,8 @@ public class BookMarkRequest {
 
         private List<HashTag> hashTags;
 
+        private Long memberId;
+
     }
 
 

--- a/src/main/java/umc/project/umark/domain/bookmark/service/BookMarkService.java
+++ b/src/main/java/umc/project/umark/domain/bookmark/service/BookMarkService.java
@@ -10,6 +10,6 @@ public interface BookMarkService {
     BookMark createBookMark(BookMarkRequest.BookMarkCreateRequestDTO request);
     BookMark likeBookMark(Long memberId, Long bookMarkId);
 
-    //Long deleteBookMark(Long memberId, Long bookMarkId);
+    Long deleteBookMark(Long memberId, Long bookMarkId);
 
 }

--- a/src/main/java/umc/project/umark/domain/bookmark/service/BookMarkServiceImpl.java
+++ b/src/main/java/umc/project/umark/domain/bookmark/service/BookMarkServiceImpl.java
@@ -39,7 +39,12 @@ public class BookMarkServiceImpl implements BookMarkService{
     @Override
     @Transactional
     public BookMark createBookMark(BookMarkRequest.BookMarkCreateRequestDTO request) {  //북마크 생성
-        BookMark newBookMark = BookMarkConverter.toBookMark(request); // dto를 엔티티로 바꾼거
+        Long memberId = request.getMemberId();
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GlobalException(GlobalErrorCode.MEMBER_NOT_FOUND));
+
+        BookMark newBookMark = BookMarkConverter.toBookMark(request,member); // dto를 엔티티로 바꾼거
 
         List<HashTag> hashTagList = request.getHashTags().stream()
                 .map(hashTag -> {
@@ -48,6 +53,8 @@ public class BookMarkServiceImpl implements BookMarkService{
 
         List <BookMarkHashTag> bookMarkHashTagList = BookMarkHashTagConverter.toBookMarkHashTagList(hashTagList); //request에 있는 것들로 bookmarkhashtag 만들기
         bookMarkHashTagList.forEach(bookMarkHashTag -> bookMarkHashTag.setBookMark(newBookMark));
+
+        member.increaseWrittenCount();
         return bookMarkRepository.save(newBookMark);
 
     }
@@ -70,6 +77,7 @@ public class BookMarkServiceImpl implements BookMarkService{
         if(existingLike.isPresent()){
             BookMarkLike bookMarkLike = existingLike.get();
             bookmark.decreaseLikeCount();  // 좋아요 수 감소
+            member.decreaseLikedCount();   //내가 좋아요 한 수 감소
             bookMarkLikeRepository.deleteById(bookMarkLike.getId());  // BookMarkLike 엔터티 삭제
 
         }
@@ -77,7 +85,7 @@ public class BookMarkServiceImpl implements BookMarkService{
         else{
         // likeCount 증가
         bookmark.increaseLikeCount();
-
+        member.increaseLikedCount();
         //BookMarkLike에 멤버, 북마크 객체 주입
          BookMarkLike newBookMarkLike = BookMarkLikeConverter.toBookMarkLike(member);
          newBookMarkLike.setBookMark(bookmark);
@@ -87,24 +95,27 @@ public class BookMarkServiceImpl implements BookMarkService{
 
     }
 
-//    @Override
-//    @Transactional
-//    public Long deleteBookMark(Long memberId, Long bookMarkId){
-//        //멤버가 존재하는지 검증
-//        Member member = memberRepository.findById(memberId)
-//                .orElseThrow(() -> new GlobalException(GlobalErrorCode.MEMBER_NOT_FOUND));
-//
-//        //게시물이 존재하는지 검증
-//        BookMark bookmark = bookMarkRepository.findById(bookMarkId)
-//                .orElseThrow(() -> new GlobalException(GlobalErrorCode.BOOKMARK_NOT_FOUND));
-//
-//        if (bookmark.getMember().getId() != memberId) {
-//            //만약 게시물의 작성자와 삭제하고자 하는 멤버의 id가 다르다면
-//            throw new GlobalException(GlobalErrorCode.MEMBER_NOT_AUTHORIZED);
-//        }
-//
-//        return bookmark.getId();
-//
-//    }
+   @Override
+   @Transactional
+   public Long deleteBookMark(Long memberId, Long bookMarkId){
+       //멤버가 존재하는지 검증
+       Member member = memberRepository.findById(memberId)
+               .orElseThrow(() -> new GlobalException(GlobalErrorCode.MEMBER_NOT_FOUND));
+
+       //게시물이 존재하는지 검증
+       BookMark bookmark = bookMarkRepository.findById(bookMarkId)
+               .orElseThrow(() -> new GlobalException(GlobalErrorCode.BOOKMARK_NOT_FOUND));
+
+       if (!bookmark.getMember().equals(member)) {
+           //만약 게시물의 작성자와 삭제하고자 하는 멤버의 id가 다르다면
+           throw new GlobalException(GlobalErrorCode.MEMBER_NOT_AUTHORIZED);
+       }
+
+       Long deletedBookMarkId = bookmark.getId();         //삭제할 북마크의 아이디 저장
+       bookMarkRepository.deleteById(bookmark.getId());   //북마크 삭제 cascade.all타입이므로 관련 mapping table은 자동 삭제
+       member.decreaseWrittenCount();
+       return deletedBookMarkId;
+
+   }
 
 }


### PR DESCRIPTION
1. 북마크 생성 시 request로 memberId를 받아 bookmark entity 객체 주입을 해줌. (bookmark 생성 때 놓친 부분 수정)
2. 북마크 생성 시 member의 wriitencount+1
3. 북마크 좋아요 생성 시 member가 누른 좋아요 수 증감 기능 추가 
4. 북마크 삭제
  -북마크와 멤버의 존재 여부 검증
  - bookmark.getMember().equals(member)을 통해 작성자와 삭제요구자가 같은지 검증
  - 북마크 삭제
  - 삭제한 북마크 아이디 반환
5. cascade타입으로 bookmark와 관련된 mapping table은 자동으로 삭제됨.