### PR TITLE
Feature/34-약관 추가 및 전체 조회

### DIFF
--- a/src/main/java/umc/project/umark/domain/term/controller/TermController.java
+++ b/src/main/java/umc/project/umark/domain/term/controller/TermController.java
@@ -2,11 +2,15 @@ package umc.project.umark.domain.term.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import umc.project.umark.domain.term.dto.TermDto;
 import umc.project.umark.domain.term.service.TermService;
+import umc.project.umark.global.common.ApiResponse;
+
+import java.util.List;
 
 
 @RestController
@@ -14,14 +18,19 @@ import umc.project.umark.domain.term.service.TermService;
 @Slf4j
 public class TermController {
 
-//    private final TermService termService;
+    private final TermService termService;
 
-//    @PostMapping("/term/add")
-//    public Object addTerm(
-//            @RequestBody TermDto.TermRequestDto requestDto
-//    ) {
-//        termService.createTerm(requestDto);
-//        return null;
-//    }
+    @PostMapping("/term/add")
+    public ApiResponse addTerm(
+            @RequestBody TermDto.TermRequestDto requestDto
+    ) {
+        termService.createTerm(requestDto);
+        return ApiResponse.onSuccess("");
+    }
+
+    @GetMapping("/terms")
+    public ApiResponse<List<TermDto.TermResponseDto>> getTerms() {
+        return ApiResponse.onSuccess(termService.getTerms());
+    }
 
 }

--- a/src/main/java/umc/project/umark/domain/term/converter/TermConverter.java
+++ b/src/main/java/umc/project/umark/domain/term/converter/TermConverter.java
@@ -1,0 +1,32 @@
+package umc.project.umark.domain.term.converter;
+
+import org.springframework.stereotype.Component;
+import umc.project.umark.domain.term.dto.TermDto;
+import umc.project.umark.domain.term.entity.Term;
+
+import java.util.List;
+
+@Component
+public class TermConverter {
+
+    public Term toTerm(String title, String description, Boolean isCrucial) {
+        return Term.builder()
+                .title(title)
+                .description(description)
+                .isCrucial(isCrucial)
+                .build();
+    }
+
+    public TermDto.TermResponseDto toTermResponseDto(Term term) {
+        return TermDto.TermResponseDto.builder()
+                .id(term.getId())
+                .title(term.getTitle())
+                .description(term.getDescription())
+                .isCrucial(term.getIsCrucial())
+                .build();
+    }
+
+    public List<TermDto.TermResponseDto> toGetTerms(List<Term> terms) {
+        return terms.stream().map(this::toTermResponseDto).toList();
+    }
+}

--- a/src/main/java/umc/project/umark/domain/term/dto/TermDto.java
+++ b/src/main/java/umc/project/umark/domain/term/dto/TermDto.java
@@ -12,8 +12,19 @@ public class TermDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class TermRequestDto {
+        String title;
         String description;
-        Boolean isAgree;
+        Boolean isCrucial;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TermResponseDto {
+        Long id;
+        String title;
+        String description;
         Boolean isCrucial;
     }
 }

--- a/src/main/java/umc/project/umark/domain/term/entity/Term.java
+++ b/src/main/java/umc/project/umark/domain/term/entity/Term.java
@@ -20,6 +20,9 @@ public class Term extends BaseEntity {
     private Member member;
 
     @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
     private String description;
 
     @Column(nullable = false)

--- a/src/main/java/umc/project/umark/domain/term/service/TermService.java
+++ b/src/main/java/umc/project/umark/domain/term/service/TermService.java
@@ -1,7 +1,11 @@
 package umc.project.umark.domain.term.service;
 
 import umc.project.umark.domain.term.dto.TermDto;
+import umc.project.umark.domain.term.entity.Term;
+
+import java.util.List;
 
 public interface TermService {
     public void createTerm(TermDto.TermRequestDto requestDto);
+    public List<TermDto.TermResponseDto> getTerms();
 }

--- a/src/main/java/umc/project/umark/domain/term/service/TermServiceImpl.java
+++ b/src/main/java/umc/project/umark/domain/term/service/TermServiceImpl.java
@@ -1,34 +1,40 @@
-//package umc.project.umark.domain.term.service;
-//
-//import lombok.RequiredArgsConstructor;
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.stereotype.Service;
-//import org.springframework.transaction.annotation.Transactional;
-//import umc.project.umark.domain.term.dto.TermDto;
-//import umc.project.umark.domain.term.entity.Term;
-//import umc.project.umark.domain.term.repository.TermRepository;
-//import umc.project.umark.global.exception.GlobalErrorCode;
-//import umc.project.umark.global.exception.GlobalException;
-//
-//@Service
-//@RequiredArgsConstructor
-//@Slf4j
-//public class TermServiceImpl implements TermService{
-//    private final TermRepository termRepository;
-//
-////    @Override
-////    @Transactional
-////    public void createTerm(TermDto.TermRequestDto requestDto) {
-////        if (requestDto.getIsAgree() == null) {
-////            throw new GlobalException(GlobalErrorCode.MEMBER_NOT_FOUND);
-////        };
-////        Term newTerm =  Term.builder()
-////                .description(requestDto.getDescription())
-////                .isCrucial(requestDto.getIsCrucial())
-////                .build();
-////
-////        termRepository.save(newTerm);
-////
-////        log.info("New Term created with id: {}", newTerm.getId());
-////    }
-//}
+package umc.project.umark.domain.term.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.project.umark.domain.term.converter.TermConverter;
+import umc.project.umark.domain.term.dto.TermDto;
+import umc.project.umark.domain.term.entity.Term;
+import umc.project.umark.domain.term.repository.TermRepository;
+import umc.project.umark.global.exception.GlobalErrorCode;
+import umc.project.umark.global.exception.GlobalException;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TermServiceImpl implements TermService{
+    private final TermRepository termRepository;
+    private final TermConverter termConverter;
+
+    @Override
+    @Transactional
+    public void createTerm(TermDto.TermRequestDto requestDto) {
+        Term newTerm =  termConverter.toTerm(requestDto.getTitle(),
+                requestDto.getDescription(), requestDto.getIsCrucial());
+
+        termRepository.save(newTerm);
+
+        log.info("New Term created with id: {}", newTerm.getId());
+    }
+    @Override
+    @Transactional
+    public List<TermDto.TermResponseDto> getTerms() {
+        List<Term> terms = termRepository.findAll();
+        return termConverter.toGetTerms(terms);
+    }
+
+}


### PR DESCRIPTION
# 개요 
약관을 추가하는 API(테스트용으로, DB에 직접 저장한다면 사라질듯)
저장된 모든 약관을 조회하는 API

## 작업 내용
**POST** /term/add - 약관 추가
**GET** /terms - 약관 조회