### PR TITLE
[FEAT] #38-이벤트 조회 수정 api

### DIFF
--- a/src/main/java/umc/project/umark/UmarkApplication.java
+++ b/src/main/java/umc/project/umark/UmarkApplication.java
@@ -2,9 +2,11 @@ package umc.project.umark;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class UmarkApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/umc/project/umark/domain/bookmark/controller/BookMarkController.java
+++ b/src/main/java/umc/project/umark/domain/bookmark/controller/BookMarkController.java
@@ -3,8 +3,10 @@ package umc.project.umark.domain.bookmark.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 import umc.project.umark.domain.bookmark.converter.BookMarkConverter;
+import umc.project.umark.domain.bookmark.dto.Response.BookMarkInquiryResponse;
 import umc.project.umark.domain.bookmark.dto.Response.BookMarkResponse;
 import umc.project.umark.domain.bookmark.dto.Request.BookMarkRequest;
 import umc.project.umark.domain.bookmark.entity.BookMark;
@@ -18,6 +20,7 @@ import umc.project.umark.domain.report.converter.ReportConverter;
 import umc.project.umark.domain.report.dto.Request.ReportRequest;
 import umc.project.umark.domain.report.dto.Response.ReportResponse;
 import umc.project.umark.global.common.ApiResponse;
+import umc.project.umark.global.exception.GlobalErrorCode;
 import umc.project.umark.global.exception.GlobalException;
 
 @RestController
@@ -60,5 +63,66 @@ public class BookMarkController {
         return ApiResponse.onSuccess(ReportConverter.toReportCreateResponseDTO(newReport));
 
     }
+
+    @GetMapping("/") // 모든 북마크 조회
+    public ApiResponse<Page<BookMarkInquiryResponse>> inquiryBookMark(@RequestParam(name = "page") Integer page) {
+        try {
+            return ApiResponse.onSuccess(bookMarkService.inquiryBookMarkPage(page));
+        } catch (GlobalException e) {
+            return ApiResponse.onFailure(e.getErrorCode(), null);
+        }
+    }
+
+    @GetMapping("/recommends") // 추천 북마크 조회
+    public ApiResponse<Page<BookMarkInquiryResponse>> inquiryBookMarkByLikeCount(@RequestParam(name = "page") Integer page){
+        try {
+            return ApiResponse.onSuccess(bookMarkService.inquiryBookMarkByLikeCount(page));
+        } catch (GlobalException e) {
+            return ApiResponse.onFailure(e.getErrorCode(), null);
+        }
+    }
+    @GetMapping("/{memberId}/mywrite") // 내가 쓴 북마크 조회
+    public ApiResponse<Page<BookMarkInquiryResponse>> inquiryBookMarkByMember(
+            @RequestParam(name = "page") Integer page,
+            @PathVariable Long memberId
+    ) {
+        try {
+            return ApiResponse.onSuccess(bookMarkService.inquiryBookMarkByMember(memberId, page));
+        } catch (GlobalException e) {
+            return  ApiResponse.onFailure(e.getErrorCode(), null);
+        }
+    }
+
+    @GetMapping("/{memberId}/mylike") // 내가 좋아요한 북마크 조회
+    public ApiResponse<Page<BookMarkInquiryResponse>> inquiryBookMarkByMemberLike(
+            @RequestParam(name = "page") Integer page,
+            @PathVariable Long memberId
+    ) {
+        try {
+            return ApiResponse.onSuccess(bookMarkService.inquiryBookMarkByMemberLike(memberId, page));
+        } catch (GlobalException e) {
+            return ApiResponse.onFailure(e.getErrorCode(), null);
+        }
+    }
+
+    @GetMapping("/search") // 북마크 검색
+    public ApiResponse<Page<BookMarkInquiryResponse>> inquiryBookMarkBySearch(
+            @RequestParam(name = "page") Integer page,
+            @RequestParam String keyWord
+    ) {
+        try {
+            if (keyWord == null) {
+                throw new GlobalException(GlobalErrorCode.NOT_VALID_KEYWORD);
+            } else {
+                return ApiResponse.onSuccess(bookMarkService.inquiryBookMarkBySearch(keyWord, page));
+            }
+        } catch (GlobalException e) {
+            return ApiResponse.onFailure(e.getErrorCode(), null);
+        }
+    }
+    /*@PutMapping("/bookmarks/{bookMarkid}")//북마크 수정
+    public ApiResponse<BookMarkResponse> updateBookMark(@PathVariable Long id, @RequestBody BookMarkRequest.BookMarkUpdateRequest request){
+        return ApiResponse.onSuccess(bookMarkService.updateBookMark(memberId, page));;
+    }*/
 
 }

--- a/src/main/java/umc/project/umark/domain/bookmark/converter/BookMarkConverter.java
+++ b/src/main/java/umc/project/umark/domain/bookmark/converter/BookMarkConverter.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import umc.project.umark.domain.bookmark.dto.Response.BookMarkInquiryResponse;
 import umc.project.umark.domain.bookmark.dto.Response.BookMarkResponse;
 import umc.project.umark.domain.bookmark.dto.Request.BookMarkRequest;
 import umc.project.umark.domain.bookmark.entity.BookMark;
@@ -13,9 +15,12 @@ import umc.project.umark.domain.member.repository.MemberRepository;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Slf4j
+@Component
 public class BookMarkConverter {
 
     public static BookMarkResponse.BookMarkCreateResponseDTO toBookMarkCreateResponseDTO(BookMark bookMark){ //response dto 생성
@@ -47,6 +52,22 @@ public class BookMarkConverter {
                 .deletedAt(LocalDateTime.now())
                 .build();
 
+    }
+
+    public BookMarkInquiryResponse toBookMarkInquiryResponse(BookMark bookmark){
+        List<String> hashTagContent = bookmark.getBookMarkHashTags().stream()
+                .map(bookMarkHashTag -> bookMarkHashTag.getHashtag().getContent())
+                .collect(Collectors.toList());
+
+
+        return BookMarkInquiryResponse.builder()
+                .id(bookmark.getId())
+                .title(bookmark.getTitle())
+                .createdAt(bookmark.getCreatedAt())
+                .hashTagContent(hashTagContent)
+                .content(bookmark.getContent())
+                .url(bookmark.getUrl())
+                .build();
     }
 
 }

--- a/src/main/java/umc/project/umark/domain/bookmark/dto/Request/BookMarkRequest.java
+++ b/src/main/java/umc/project/umark/domain/bookmark/dto/Request/BookMarkRequest.java
@@ -30,5 +30,21 @@ public class BookMarkRequest {
 
     }
 
+    @Getter
+    public static class BookMarkUpdateRequest{
+
+        @Size(max = 20)
+        private String title;
+
+        @Size(max = 20)
+        private String url;
+
+        @Size(max = 250)
+        private String content;
+
+        private List<HashTag> hashTags;
+
+    }
+
 
 }

--- a/src/main/java/umc/project/umark/domain/bookmark/dto/Response/BookMarkInquiryResponse.java
+++ b/src/main/java/umc/project/umark/domain/bookmark/dto/Response/BookMarkInquiryResponse.java
@@ -1,0 +1,18 @@
+package umc.project.umark.domain.bookmark.dto.Response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class BookMarkInquiryResponse {
+    private Long id;
+    private String title;
+    private LocalDateTime createdAt;
+    private List<String> hashTagContent;
+    private String content;
+    private String url;
+}

--- a/src/main/java/umc/project/umark/domain/bookmark/dto/Response/BookMarkUpdateResponse.java
+++ b/src/main/java/umc/project/umark/domain/bookmark/dto/Response/BookMarkUpdateResponse.java
@@ -1,0 +1,15 @@
+package umc.project.umark.domain.bookmark.dto.Response;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class BookMarkUpdateResponse {
+    Long BookMarkId;
+    LocalDateTime modifiedAt;
+}
+

--- a/src/main/java/umc/project/umark/domain/bookmark/entity/BookMark.java
+++ b/src/main/java/umc/project/umark/domain/bookmark/entity/BookMark.java
@@ -77,4 +77,12 @@ public class BookMark extends BaseEntity {
         }
     }
 
+    public void update(String title, String url, String content, List<BookMarkHashTag> bookMarkHashTags){
+        this.title = title;
+        this.url = url;
+        this.content =content;
+        this.bookMarkHashTags = bookMarkHashTags;
+        markAsModified();
+    }
+
 }

--- a/src/main/java/umc/project/umark/domain/bookmark/repository/BookMarkRepository.java
+++ b/src/main/java/umc/project/umark/domain/bookmark/repository/BookMarkRepository.java
@@ -1,9 +1,27 @@
 package umc.project.umark.domain.bookmark.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import umc.project.umark.domain.bookmark.entity.BookMark;
+import umc.project.umark.domain.member.entity.Member;
+
+import java.time.LocalDateTime;
+
 @Repository
 public interface BookMarkRepository extends JpaRepository<BookMark, Long> {
-    
+
+    Page<BookMark> findAll(Pageable pageable);
+
+    @Query("SELECT b FROM BookMark b WHERE b.createdAt >= :weekAgo AND b.likeCount > 0 ORDER BY b.likeCount DESC")
+    Page<BookMark> findAllByOrderByLikeCount(Pageable pageable, @Param("weekAgo") LocalDateTime weekAgo);
+    Page<BookMark> findAllByMember(Member member, Pageable pageable);
+
+    @Query("SELECT DISTINCT  b FROM BookMark b JOIN b.bookMarkHashTags t WHERE t.hashtag.content LIKE %:keyword% AND b.createdAt >= :weekAgo")
+    Page<BookMark> findAllBySearch(String keyword, Pageable pageable, @Param("weekAgo") LocalDateTime weekAgo);
+
 }

--- a/src/main/java/umc/project/umark/domain/bookmark/service/BookMarkService.java
+++ b/src/main/java/umc/project/umark/domain/bookmark/service/BookMarkService.java
@@ -1,7 +1,9 @@
 package umc.project.umark.domain.bookmark.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import umc.project.umark.domain.bookmark.dto.Request.BookMarkRequest;
+import umc.project.umark.domain.bookmark.dto.Response.BookMarkInquiryResponse;
 import umc.project.umark.domain.bookmark.entity.BookMark;
 import umc.project.umark.domain.hashtag.service.HashTagService;
 import umc.project.umark.domain.mapping.BookMarkLike;
@@ -14,4 +16,11 @@ public interface BookMarkService {
     Long deleteBookMark(Long memberId, Long bookMarkId);
     Report createReport(ReportRequest.ReportRequestDTO request);
 
+    Page<BookMarkInquiryResponse> inquiryBookMarkPage(Integer page);//모든 북마크 조회
+    Page<BookMarkInquiryResponse> inquiryBookMarkByLikeCount(Integer page); // 추천 북마크 조회
+    Page<BookMarkInquiryResponse> inquiryBookMarkByMemberLike(Long memberId, Integer page); // 좋아요 한 북마크 조회
+    Page<BookMarkInquiryResponse> inquiryBookMarkByMember(Long memberId, Integer page); // 내가 쓴 북마크 조회
+    Page<BookMarkInquiryResponse> inquiryBookMarkBySearch(String keyWord, Integer page); // 북마크 검색
+
+    //BookMarkUpdateResponse updateBookMark(Long bookMarkId, BookMarkRequest.BookMarkUpdateRequest requset);
 }

--- a/src/main/java/umc/project/umark/domain/mapping/repository/BookMarkLikeRepository.java
+++ b/src/main/java/umc/project/umark/domain/mapping/repository/BookMarkLikeRepository.java
@@ -1,5 +1,7 @@
 package umc.project.umark.domain.mapping.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import umc.project.umark.domain.bookmark.entity.BookMark;
@@ -9,5 +11,6 @@ import umc.project.umark.domain.member.entity.Member;
 import java.util.Optional;
 @Repository
 public interface BookMarkLikeRepository  extends JpaRepository<BookMarkLike, Long> {
+    Page<BookMarkLike> findAllByMember(Member member, PageRequest pageRequest);
     Optional<BookMarkLike> findByMemberAndBookmark(Member member, BookMark bookmark);
 }

--- a/src/main/java/umc/project/umark/global/common/BaseEntity.java
+++ b/src/main/java/umc/project/umark/global/common/BaseEntity.java
@@ -2,6 +2,7 @@ package umc.project.umark.global.common;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -9,6 +10,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @MappedSuperclass
+@Getter
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 
@@ -19,6 +21,10 @@ public abstract class BaseEntity {
     private LocalDateTime modifiedAt;
 
     private LocalDateTime deletedAt;
+
+    public void markAsModified() {
+        this.modifiedAt = LocalDateTime.now();
+    }
 
     public void markAsDeleted() {
         this.deletedAt = LocalDateTime.now();

--- a/src/main/java/umc/project/umark/global/exception/GlobalErrorCode.java
+++ b/src/main/java/umc/project/umark/global/exception/GlobalErrorCode.java
@@ -18,6 +18,7 @@ public enum GlobalErrorCode {
     NOT_VALID_PASSWORD(BAD_REQUEST, "영문, 숫자, 특수문자를 포함한 8~20 글자를 입력해 주세요."),
     WRONG_EMAIL_FORM(BAD_REQUEST, "잘못된 이메일 형식입니다."),
     NOT_MATCH_CODE(BAD_REQUEST, "코드가 일치하지 않습니다"),
+    NOT_VALID_KEYWORD(BAD_REQUEST, "유효하지 않은 검색어 입니다."),
 
     // 401 Unauthorized - 권한 없음
     INVALID_TOKEN(UNAUTHORIZED, "토큰이 유효하지 않습니다."),
@@ -30,7 +31,6 @@ public enum GlobalErrorCode {
     NEED_AGREE_REQUIRE_TERMS(NOT_FOUND, "필수 약관에 동의해 주세요."),
     MEMBER_NOT_FOUND(NOT_FOUND, "등록된 사용자가 없습니다."),
     MEMBER_INFO_NOT_FOUND(NOT_FOUND, "등록된 사용자 정보가 없습니다."),
-
     BOOKMARK_NOT_FOUND(NOT_FOUND, "존재하는 북마크가 없습니다."),
     // 409 CONFLICT : Resource 를 찾을 수 없음
     DUPLICATE_EMAIL(CONFLICT, "중복된 이메일이 존재합니다."),


### PR DESCRIPTION
1.모든 북마크 조회 GET/bookmarks
2.추천 북마크 조회 GET/bookmarks/recommends
3.내가 쓴 북마크 조회 GET/bookmarks/{memberId}/mywrite
4.내가 좋아요한 북마크 조회 GET/bookmarks/search
5.모든 북마크에서 검색 GET/bookmarks/search
6.북마크 수정 PUT/bookmarks/{bookmarkid}

모든 북마크 조회는 최신순으로 했고
추천 북마크는 우선 1달 이내 게시물중에 likecount가 10이상인 게시물들을 likecount가 큰 순으로 조회되게 했습니다.
