### PR TITLE
Feature/#31 create report

### DIFF
--- a/src/main/java/umc/project/umark/domain/bookmark/controller/BookMarkController.java
+++ b/src/main/java/umc/project/umark/domain/bookmark/controller/BookMarkController.java
@@ -59,8 +59,8 @@ public class BookMarkController {
     @PostMapping("/reports")
     public ApiResponse<ReportResponse.ReportResponseDTO> createReport(@RequestBody ReportRequest.ReportRequestDTO request) {
 
-        Report newReport = bookMarkService.createReport(request);
-        return ApiResponse.onSuccess(ReportConverter.toReportCreateResponseDTO(newReport));
+       BookMark bookmark = bookMarkService.createReport(request);
+        return ApiResponse.onSuccess(ReportConverter.toReportCreateResponseDTO(bookmark));
 
     }
 

--- a/src/main/java/umc/project/umark/domain/bookmark/entity/BookMark.java
+++ b/src/main/java/umc/project/umark/domain/bookmark/entity/BookMark.java
@@ -37,6 +37,9 @@ public class BookMark extends BaseEntity {
     private boolean isModified = false;
 
     @Column(nullable = false)
+    private boolean isReported = false;
+
+    @Column(nullable = false)
     @Builder.Default
     private Integer likeCount=0;
 
@@ -83,6 +86,9 @@ public class BookMark extends BaseEntity {
         this.content =content;
         this.bookMarkHashTags = bookMarkHashTags;
         markAsModified();
+    }
+    public void setReported(boolean reported) {
+        this.isReported = reported;
     }
 
 }

--- a/src/main/java/umc/project/umark/domain/bookmark/service/BookMarkService.java
+++ b/src/main/java/umc/project/umark/domain/bookmark/service/BookMarkService.java
@@ -14,7 +14,7 @@ public interface BookMarkService {
     BookMark createBookMark(BookMarkRequest.BookMarkCreateRequestDTO request);
     BookMark likeBookMark(Long memberId, Long bookMarkId);
     Long deleteBookMark(Long memberId, Long bookMarkId);
-    Report createReport(ReportRequest.ReportRequestDTO request);
+    BookMark createReport(ReportRequest.ReportRequestDTO request);
 
     Page<BookMarkInquiryResponse> inquiryBookMarkPage(Integer page);//모든 북마크 조회
     Page<BookMarkInquiryResponse> inquiryBookMarkByLikeCount(Integer page); // 추천 북마크 조회

--- a/src/main/java/umc/project/umark/domain/bookmark/service/BookMarkServiceImpl.java
+++ b/src/main/java/umc/project/umark/domain/bookmark/service/BookMarkServiceImpl.java
@@ -132,7 +132,7 @@ public class BookMarkServiceImpl implements BookMarkService{
 
     @Override
     @Transactional
-    public Report createReport(ReportRequest.ReportRequestDTO request){
+    public BookMark createReport(ReportRequest.ReportRequestDTO request){    //북마크에 신고 누르기
         Long memberId = request.getMemberId();
 
         Member member = memberRepository.findById(memberId)
@@ -146,7 +146,11 @@ public class BookMarkServiceImpl implements BookMarkService{
         Report newReport = ReportConverter.toReport(request);
         newReport.setBookMark(bookmark);
         bookmark.increaseReportCount();
-        return reportRepository.save(newReport);
+        if(bookmark.getReportCount()>=10){          //신고 누적 수가 10이상이면 북마크 상태가 신고됨으로 바뀜.
+           bookmark.setReported(true);
+        }
+        reportRepository.save(newReport);
+        return bookmark;
     }
 
     @Override // 모든 북마크 조회

--- a/src/main/java/umc/project/umark/domain/report/converter/ReportConverter.java
+++ b/src/main/java/umc/project/umark/domain/report/converter/ReportConverter.java
@@ -1,6 +1,7 @@
 package umc.project.umark.domain.report.converter;
 
 import lombok.extern.slf4j.Slf4j;
+import umc.project.umark.domain.bookmark.entity.BookMark;
 import umc.project.umark.domain.report.Report;
 import umc.project.umark.domain.report.ReportType;
 import umc.project.umark.domain.report.dto.Request.ReportRequest;
@@ -34,13 +35,14 @@ public class ReportConverter {
                 .build();
 
     }
-    public static ReportResponse.ReportResponseDTO toReportCreateResponseDTO(Report report){ //response dto 생성
-        ReportType reportType = report.getReportType();
-        String description = (reportType != null) ? reportType.getDescription() : null;
+    public static ReportResponse.ReportResponseDTO toReportCreateResponseDTO(BookMark bookmark){ //response dto 생성
+//        ReportType reportType = report.getReportType();
+//        String description = (reportType != null) ? reportType.getDescription() : null;
 
         return  ReportResponse.ReportResponseDTO.builder()
-                .reportId(report.getId())
-                .selectedType(description)
+                .bookMarkId(bookmark.getId())
+                .reportCount(bookmark.getReportCount())
+                .isReported(bookmark.isReported())
                 .createdAt(LocalDateTime.now())
                 .build();
 

--- a/src/main/java/umc/project/umark/domain/report/converter/ReportConverter.java
+++ b/src/main/java/umc/project/umark/domain/report/converter/ReportConverter.java
@@ -36,14 +36,12 @@ public class ReportConverter {
 
     }
     public static ReportResponse.ReportResponseDTO toReportCreateResponseDTO(BookMark bookmark){ //response dto 생성
-//        ReportType reportType = report.getReportType();
-//        String description = (reportType != null) ? reportType.getDescription() : null;
 
         return  ReportResponse.ReportResponseDTO.builder()
                 .bookMarkId(bookmark.getId())
                 .reportCount(bookmark.getReportCount())
                 .isReported(bookmark.isReported())
-                .createdAt(LocalDateTime.now())
+                .reportCreatedAt(LocalDateTime.now())
                 .build();
 
     }

--- a/src/main/java/umc/project/umark/domain/report/dto/Response/ReportResponse.java
+++ b/src/main/java/umc/project/umark/domain/report/dto/Response/ReportResponse.java
@@ -15,8 +15,9 @@ public class ReportResponse {
     @AllArgsConstructor
     public static class ReportResponseDTO{
 
-        Long reportId;
-        String selectedType;
+        Long bookMarkId;
+        Integer reportCount;
+        boolean isReported;
         LocalDateTime createdAt;
 
     }

--- a/src/main/java/umc/project/umark/domain/report/dto/Response/ReportResponse.java
+++ b/src/main/java/umc/project/umark/domain/report/dto/Response/ReportResponse.java
@@ -18,7 +18,7 @@ public class ReportResponse {
         Long bookMarkId;
         Integer reportCount;
         boolean isReported;
-        LocalDateTime createdAt;
+        LocalDateTime reportCreatedAt;
 
     }
 }


### PR DESCRIPTION
1. Bookmark 엔티티에 boolean isReported 컬럼추가(디폴트값: false)
2. 북마크의 신고 누적 수가 10개 이상이면 isReported 컬럼이 true로 변환
3. responseDTO에 reportId, reportType 대신 bookmarkId, bookmark의 누적 신고 수, isReported가 true인지 false인지 담기게 됨.
4. 신고누적 10개이상 북마크는 바로 삭제 처리가 안되고 신고된 게시물로 보여지게 됨.(pm분과 상의 완료)